### PR TITLE
feat: add multi-board support with per-board configs and wiring docs


### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,9 @@ on:
     branches: [ main ]
 
 jobs:
-  # ─────────────────────────────────────────────────────────────────────────────
-  # Native unit tests (no hardware, fast)
-  # ─────────────────────────────────────────────────────────────────────────────
+  # ───────────────────────────────────────────────────────────────────────────
+  # Native unit tests (no hardware, runs fast on every push)
+  # ───────────────────────────────────────────────────────────────────────────
   test:
     name: Native Tests
     runs-on: ubuntu-latest
@@ -35,13 +35,51 @@ jobs:
       - name: Run native tests
         run: pio test -e native -v
 
-  # ─────────────────────────────────────────────────────────────────────────────
-  # Firmware build for ESP32-S3 (verifies the embedded build compiles cleanly)
-  # ─────────────────────────────────────────────────────────────────────────────
+  # ───────────────────────────────────────────────────────────────────────────
+  # Firmware builds — one job per board, run in parallel after tests pass.
+  #
+  # Matrix columns:
+  #   env      — PlatformIO environment name (must match [env:*] in pio.ini)
+  #   platform — used to key the package cache (esp32 | nrf52)
+  #   artifact — name of the uploaded firmware artifact
+  # ───────────────────────────────────────────────────────────────────────────
   firmware:
-    name: Firmware Build (ESP32-S3)
+    name: Build ${{ matrix.env }}
     runs-on: ubuntu-latest
     needs: test
+    strategy:
+      fail-fast: false   # keep building other boards if one fails
+      matrix:
+        include:
+          # ── ESP32 family (full MCP server) ─────────────────────────────────
+          - env: esp32-s3-devkitc-1
+            platform: esp32
+            artifact: firmware-esp32s3-devkitc1
+
+          - env: esp32-devkitc
+            platform: esp32
+            artifact: firmware-esp32-devkitc
+
+          - env: esp32-c3-devkitm-1
+            platform: esp32
+            artifact: firmware-esp32c3-devkitm1
+
+          - env: adafruit-huzzah32
+            platform: esp32
+            artifact: firmware-adafruit-huzzah32
+
+          - env: m5stack-core
+            platform: esp32
+            artifact: firmware-m5stack-core
+
+          # ── nRF52840 family (sensor-only build) ────────────────────────────
+          - env: nrf52840-dk
+            platform: nrf52
+            artifact: firmware-nrf52840-dk
+
+          - env: nrf52840-feather
+            platform: nrf52
+            artifact: firmware-nrf52840-feather
 
     steps:
       - uses: actions/checkout@v4
@@ -55,21 +93,28 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.platformio
-          key: pio-esp32s3-${{ hashFiles('platformio.ini') }}
-          restore-keys: pio-esp32s3-
+          key: pio-${{ matrix.platform }}-${{ matrix.env }}-${{ hashFiles('platformio.ini') }}
+          restore-keys: |
+            pio-${{ matrix.platform }}-${{ matrix.env }}-
+            pio-${{ matrix.platform }}-
 
       - name: Install PlatformIO
         run: pip install platformio
 
       - name: Install library dependencies
-        run: pio pkg install -e esp32-s3-devkitc-1
+        run: pio pkg install -e ${{ matrix.env }}
 
       - name: Build firmware
-        run: pio run -e esp32-s3-devkitc-1
+        run: pio run -e ${{ matrix.env }}
 
       - name: Upload firmware artifact
         uses: actions/upload-artifact@v4
         with:
-          name: firmware
-          path: .pio/build/esp32-s3-devkitc-1/firmware.bin
+          name: ${{ matrix.artifact }}
+          # nRF builds produce firmware.hex; ESP32 produces firmware.bin.
+          # The glob below captures whichever exists.
+          path: |
+            .pio/build/${{ matrix.env }}/firmware.bin
+            .pio/build/${{ matrix.env }}/firmware.hex
+          if-no-files-found: warn
           retention-days: 14

--- a/docs/boards/adafruit-huzzah32.md
+++ b/docs/boards/adafruit-huzzah32.md
@@ -1,0 +1,126 @@
+# Adafruit HUZZAH32 ESP32 Feather
+
+## Overview
+
+| Item | Value |
+|------|-------|
+| Chip | ESP32 (dual-core Xtensa LX6 @ 240 MHz) |
+| Flash | 4 MB |
+| PSRAM | None |
+| Connectivity | 2.4 GHz WiFi 4 + Bluetooth 4.2 + BLE |
+| USB | Micro-USB via CP2104 UART bridge |
+| LiPo charging | Yes — JST 2-pin connector with onboard MCP73831 charger |
+| Form factor | Adafruit Feather (compatible with FeatherWings) |
+| MCP transport | Full (WebSocket + mDNS + UDP discovery) |
+| PlatformIO env | `adafruit-huzzah32` |
+| Where to buy | [Adafruit #3405](https://www.adafruit.com/product/3405), Amazon, Digi-Key |
+
+## Pinout Reference
+
+```
+             Adafruit HUZZAH32 ESP32 Feather
+          ┌────────────────────────────────┐
+  RST ─── │ RST                  BAT  │ ── LiPo+
+  3V3 ─── │ 3V3                  EN   │
+  NC  ─── │ NC                   USB  │ ── 5V USB
+  GND ─── │ GND                  GND  │ ── GND
+  A0  ─── │ GPIO26               GPIO23│ ── I2C SDA
+  A1  ─── │ GPIO25               GPIO22│ ── I2C SCL
+  A2  ─── │ GPIO34 (in)          GPIO20│
+  A3  ─── │ GPIO39 (in)          GPIO21│
+  A4  ─── │ GPIO36 (in)          GPIO17│ ── UART1 TX
+  A5  ─── │ GPIO4  (CAN RX)      GPIO16│ ── UART1 RX
+  SCK ─── │ GPIO5  (CAN TX)      GPIO27│
+  MO  ─── │ GPIO18               GPIO33│
+  MI  ─── │ GPIO19               GPIO15│
+  RX  ─── │ GPIO3 (RX0)          GPIO32│
+  TX  ─── │ GPIO1 (TX0)          GPIO14│
+  SDA ─── │ GPIO23               GPIO13│ ── Red LED
+  SCL ─── │ GPIO22               GPIO12│
+          └────────────────────────────┘
+              Battery: JST (bottom left)
+```
+
+> Full pinout: https://learn.adafruit.com/adafruit-huzzah32-esp32-feather/pinouts
+
+## I2C Sensor Wiring
+
+SDA and SCL pins are labelled on the board silkscreen.
+
+```
+Adafruit HUZZAH32            I2C Sensor
+─────────────────            ──────────
+3V3  ───────────────────────  VCC / VIN
+GND  ───────────────────────  GND
+GPIO23 / SDA ───────────────  SDA
+GPIO22 / SCL ───────────────  SCL
+```
+
+### Supported Sensors
+
+| Sensor | Default I2C Address | Address Select |
+|--------|--------------------|-|
+| BME280 (temp / humidity / pressure) | 0x76 | SDO → GND = 0x76, SDO → 3V3 = 0x77 |
+| BMP280 (temp / pressure) | 0x76 | SDO → GND = 0x76, SDO → 3V3 = 0x77 |
+| MPU-6050 (accel / gyro) | 0x68 | AD0 → GND = 0x68, AD0 → 3V3 = 0x69 |
+| ADS1115 (16-bit ADC) | 0x48 | ADDR: GND=0x48, VCC=0x49, SDA=0x4A, SCL=0x4B |
+| SHT31 (temp / humidity) | 0x44 | ADDR → GND = 0x44, ADDR → 3V3 = 0x45 |
+| BH1750 (ambient light) | 0x23 | ADDR → GND = 0x23, ADDR → 3V3 = 0x5C |
+| INA219 (current / voltage) | 0x40 | A0/A1 → GND = 0x40 … see datasheet |
+
+## CAN Bus Wiring (optional)
+
+```
+Adafruit HUZZAH32            SN65HVD230 transceiver        CAN Bus
+─────────────────            ──────────────────────         ───────
+3V3  ───────────────────────  VCC (3.3 V)
+GND  ───────────────────────  GND
+GPIO5 (CAN TX / SCK) ───────  TXD
+GPIO4 (CAN RX / A5)  ───────  RXD
+                               CANH ─────────────────────── CANH
+                               CANL ─────────────────────── CANL
+```
+
+> GPIO5 and GPIO4 are shared with the SPI SCK and A5 labels; do not use SPI
+> at the same time as CAN.
+
+## UART Serial Wiring (NMEA 0183 / GPS)
+
+```
+Adafruit HUZZAH32            Serial Device
+─────────────────            ─────────────
+GND  ───────────────────────  GND
+GPIO17 (UART1 TX) ───────────  RX
+GPIO16 (UART1 RX) ───────────  TX
+```
+
+## Battery Monitor
+
+Read the approximate LiPo battery voltage with:
+
+```cpp
+int raw = analogRead(BOARD_VBAT_PIN);          // 12-bit ADC
+float v = raw * 2.0f * 3.3f / 4095.0f;        // ÷2 voltage divider
+```
+
+The `BOARD_VBAT_PIN` macro resolves to GPIO35 (labelled A13 on the board).
+
+## Build Configuration
+
+```ini
+[env:adafruit-huzzah32]
+platform  = espressif32
+board     = featheresp32
+framework = arduino
+build_flags =
+    -std=gnu++17
+    -D BOARD_ADAFRUIT_HUZZAH32
+```
+
+## Notes
+
+- Use the **3V3** pin to power sensors — never 5V (no 5V regulator output on
+  the Feather header).
+- The red **LED** on GPIO13 is shared with the SPI MISO pin; avoid SPI devices
+  if using the LED as a status indicator.
+- GPIO34, GPIO36, GPIO39 are **input-only** (no internal pull-up/down).

--- a/docs/boards/esp32-c3-devkitm-1.md
+++ b/docs/boards/esp32-c3-devkitm-1.md
@@ -1,0 +1,106 @@
+# ESP32-C3-DevKitM-1
+
+## Overview
+
+| Item | Value |
+|------|-------|
+| Chip | ESP32-C3 (single-core RISC-V @ 160 MHz) |
+| Flash | 4 MB |
+| PSRAM | None |
+| Connectivity | 2.4 GHz WiFi 4 + BLE 5.0 (no Classic BT) |
+| USB | USB-C via built-in USB Serial/JTAG (no bridge chip) |
+| MCP transport | Full (WebSocket + mDNS + UDP discovery) |
+| PlatformIO env | `esp32-c3-devkitm-1` |
+| Where to buy | Espressif Store, Mouser, DigiKey, Amazon |
+
+The ESP32-C3 is a cost-optimised IoT SoC with a RISC-V core.  It is ideal for
+battery-powered sensor nodes where processing requirements are modest.
+
+## Pinout Reference
+
+```
+                  ESP32-C3-DevKitM-1
+              ┌──────────────────────┐
+  3.3 V ──── │ 3V3           5V     │ ──── 5V (USB)
+  GND  ──── │ GND          GND     │ ──── GND
+             │ GPIO0        GPIO10  │ ──── UART1 RX
+             │ GPIO1        GPIO7   │ ──── UART1 TX
+             │ GPIO2        GPIO6   │ ──── I2C SCL
+             │ GPIO3 (CAN TX) GPIO5 │ ──── I2C SDA
+             │ GPIO4 (CAN RX) GPIO8 │ ──── WS2812 LED
+             │ GPIO20 (RX0) GPIO18  │ ──── USB D-
+             │ GPIO21 (TX0) GPIO19  │ ──── USB D+
+              └──────────────────────┘
+```
+
+> Full pinout: https://docs.espressif.com/projects/esp-idf/en/stable/esp32c3/hw-reference/esp32c3/user-guide-devkitm-1.html
+
+## I2C Sensor Wiring
+
+> **Note**: GPIO8 is used by the onboard WS2812B RGB LED.  The I2C bus is
+> therefore placed on GPIO5 (SDA) / GPIO6 (SCL) to avoid the conflict.
+
+```
+ESP32-C3-DevKitM-1           I2C Sensor
+──────────────────           ──────────
+3V3  ───────────────────────  VCC / VIN
+GND  ───────────────────────  GND
+GPIO5 (SDA) ────────────────  SDA
+GPIO6 (SCL) ────────────────  SCL
+```
+
+### Supported Sensors
+
+| Sensor | Default I2C Address | Address Select |
+|--------|--------------------|-|
+| BME280 (temp / humidity / pressure) | 0x76 | SDO → GND = 0x76, SDO → 3V3 = 0x77 |
+| BMP280 (temp / pressure) | 0x76 | SDO → GND = 0x76, SDO → 3V3 = 0x77 |
+| MPU-6050 (accel / gyro) | 0x68 | AD0 → GND = 0x68, AD0 → 3V3 = 0x69 |
+| ADS1115 (16-bit ADC) | 0x48 | ADDR: GND=0x48, VCC=0x49, SDA=0x4A, SCL=0x4B |
+| SHT31 (temp / humidity) | 0x44 | ADDR → GND = 0x44, ADDR → 3V3 = 0x45 |
+| BH1750 (ambient light) | 0x23 | ADDR → GND = 0x23, ADDR → 3V3 = 0x5C |
+| INA219 (current / voltage) | 0x40 | A0/A1 → GND = 0x40 … see datasheet |
+
+## CAN Bus Wiring (optional)
+
+```
+ESP32-C3-DevKitM-1           SN65HVD230 transceiver        CAN Bus
+──────────────────           ──────────────────────         ───────
+3V3  ───────────────────────  VCC (3.3 V)
+GND  ───────────────────────  GND
+GPIO3 (CAN TX) ──────────────  TXD
+GPIO4 (CAN RX) ──────────────  RXD
+                               CANH ─────────────────────── CANH
+                               CANL ─────────────────────── CANL
+```
+
+## UART Serial Wiring (NMEA 0183 / GPS)
+
+```
+ESP32-C3-DevKitM-1           Serial Device
+──────────────────           ─────────────
+GND  ───────────────────────  GND
+GPIO7 (UART1 TX) ────────────  RX
+GPIO10 (UART1 RX) ───────────  TX
+```
+
+## Build Configuration
+
+```ini
+[env:esp32-c3-devkitm-1]
+platform  = espressif32
+board     = esp32-c3-devkitm-1
+framework = arduino
+build_flags =
+    -std=gnu++17
+    -D BOARD_ESP32_C3_DEVKITM1
+```
+
+## Notes
+
+- **Single core**: The ESP32-C3 has only one CPU core.  The FreeRTOS task
+  `xTaskCreatePinnedToCore(..., 1)` in `main.cpp` pins to core 1; on a
+  single-core chip this silently falls back to core 0.  This is harmless.
+- **No Classic Bluetooth**: Only BLE 5.0 is available.
+- **Strapping pins**: GPIO2, GPIO8, GPIO9 affect boot mode.  GPIO8 is already
+  the LED pin; do not pull it LOW externally.

--- a/docs/boards/esp32-devkitc.md
+++ b/docs/boards/esp32-devkitc.md
@@ -1,0 +1,108 @@
+# ESP32 DevKitC V4
+
+## Overview
+
+| Item | Value |
+|------|-------|
+| Chip | ESP32 (dual-core Xtensa LX6 @ 240 MHz) |
+| Flash | 4 MB (WROOM-32) or 16 MB (WROVER) |
+| PSRAM | None (WROOM-32) / 8 MB (WROVER) |
+| Connectivity | 2.4 GHz WiFi 4 + Bluetooth 4.2 Classic + BLE |
+| USB | Micro-USB via CP2102/CH340 UART bridge |
+| MCP transport | Full (WebSocket + mDNS + UDP discovery) |
+| PlatformIO env | `esp32-devkitc` |
+| Where to buy | Amazon, AliExpress, Adafruit, SparkFun, Mouser |
+
+The classic ESP32 DevKitC is the most widely cloned ESP32 board.  Variants from
+AZ-Delivery, DOIT, Espressif, and many other vendors are all pin-compatible.
+
+## Pinout Reference
+
+```
+                    ESP32 DevKitC V4 (38-pin)
+              ┌──────────────────────────┐
+  3.3 V ──── │ 3V3               5V     │ ──── 5V (USB)
+  GND  ──── │ GND              GND     │ ──── GND
+             │ GPIO1  (TX0) ←   GPIO36  │
+             │ GPIO3  (RX0) →   GPIO39  │
+             │ GPIO21 (SDA) ─── GPIO34  │
+             │ GPIO22 (SCL) ─── GPIO35  │
+             │                  GPIO32  │
+             │ GPIO17 (TX2) ←   GPIO33  │
+             │ GPIO16 (RX2) →   GPIO25  │
+             │ GPIO5  (CAN TX)  GPIO26  │
+             │ GPIO4  (CAN RX)  GPIO27  │
+             │                  GPIO14  │
+             │                  GPIO12  │
+             │ GPIO2  (LED)     GPIO13  │
+              └──────────────────────────┘
+```
+
+> Full pinout: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/hw-reference/esp32/get-started-devkitc.html
+
+## I2C Sensor Wiring
+
+```
+ESP32 DevKitC                I2C Sensor
+─────────────                ──────────
+3V3  ──────────────────────  VCC / VIN
+GND  ──────────────────────  GND
+GPIO21 (SDA) ───────────────  SDA
+GPIO22 (SCL) ───────────────  SCL
+```
+
+### Supported Sensors
+
+| Sensor | Default I2C Address | Address Select |
+|--------|--------------------|-|
+| BME280 (temp / humidity / pressure) | 0x76 | SDO → GND = 0x76, SDO → 3V3 = 0x77 |
+| BMP280 (temp / pressure) | 0x76 | SDO → GND = 0x76, SDO → 3V3 = 0x77 |
+| MPU-6050 (accel / gyro) | 0x68 | AD0 → GND = 0x68, AD0 → 3V3 = 0x69 |
+| ADS1115 (16-bit ADC) | 0x48 | ADDR: GND=0x48, VCC=0x49, SDA=0x4A, SCL=0x4B |
+| SHT31 (temp / humidity) | 0x44 | ADDR → GND = 0x44, ADDR → 3V3 = 0x45 |
+| BH1750 (ambient light) | 0x23 | ADDR → GND = 0x23, ADDR → 3V3 = 0x5C |
+| INA219 (current / voltage) | 0x40 | A0/A1 → GND = 0x40 … see datasheet |
+
+## CAN Bus Wiring (optional)
+
+```
+ESP32 DevKitC               SN65HVD230 transceiver        CAN Bus
+─────────────               ──────────────────────         ───────
+3V3  ──────────────────────  VCC (3.3 V)
+GND  ──────────────────────  GND
+GPIO5 (CAN TX) ─────────────  TXD
+GPIO4 (CAN RX) ─────────────  RXD
+                              CANH ─────────────────────── CANH
+                              CANL ─────────────────────── CANL
+```
+
+## UART Serial Wiring (NMEA 0183 / GPS)
+
+```
+ESP32 DevKitC               Serial Device
+─────────────               ─────────────
+GND  ──────────────────────  GND
+GPIO17 (UART2 TX) ──────────  RX
+GPIO16 (UART2 RX) ──────────  TX
+```
+
+## Build Configuration
+
+```ini
+[env:esp32-devkitc]
+platform  = espressif32
+board     = esp32dev
+framework = arduino
+build_flags =
+    -std=gnu++17
+    -D BOARD_ESP32_DEVKITC
+```
+
+## Notes
+
+- **LED**: GPIO2 is connected to a plain blue LED (active HIGH) on most DevKitC
+  boards.
+- **GPIO12**: This is a strapping pin — it must be LOW at boot on WROOM-32
+  modules (already pulled low on the DevKitC board).
+- **Flash mode**: The WROVER variant allows more RAM-intensive workloads thanks
+  to 8 MB PSRAM; useful if expanding the metrics history ring buffer.

--- a/docs/boards/esp32-s3-devkitc-1.md
+++ b/docs/boards/esp32-s3-devkitc-1.md
@@ -1,0 +1,115 @@
+# ESP32-S3-DevKitC-1
+
+## Overview
+
+| Item | Value |
+|------|-------|
+| Chip | ESP32-S3 (dual-core Xtensa LX7 @ 240 MHz) |
+| Flash | 8 MB (N8R8 variant) |
+| PSRAM | 8 MB (N8R8 variant) |
+| Connectivity | 2.4 GHz WiFi 4 (802.11 b/g/n) + BLE 5.0 |
+| USB | Dual USB-C: USB JTAG/CDC + USB OTG |
+| MCP transport | Full (WebSocket + mDNS + UDP discovery) |
+| PlatformIO env | `esp32-s3-devkitc-1` |
+| Where to buy | [Espressif Store](https://www.espressif.com/en/products/devkits), Mouser, DigiKey, Amazon |
+
+## Pinout Reference
+
+```
+                    ESP32-S3-DevKitC-1
+              ┌──────────────────────────┐
+  3.3 V ──── │ 3V3               5V     │ ──── 5V (USB)
+  GND  ──── │ GND              GND     │ ──── GND
+             │ GPIO1            GPIO43  │ ──── UART0 TX
+             │ GPIO2            GPIO44  │ ──── UART0 RX
+             │ GPIO3            GPIO15  │
+             │ GPIO4  (CAN TX)  GPIO16  │ ──── UART1 RX
+             │ GPIO5  (CAN RX)  GPIO17  │ ──── UART1 TX
+             │ GPIO6            GPIO18  │
+             │ GPIO7            GPIO8   │ ──── I2C SDA
+             │ GPIO21           GPIO9   │ ──── I2C SCL
+             │                  GPIO48  │ ──── WS2812 LED
+              └──────────────────────────┘
+```
+
+> Full pinout: https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html
+
+## I2C Sensor Wiring
+
+All supported sensors share the same two-wire I2C bus (SDA = GPIO8, SCL = GPIO9).
+Power all 3.3 V sensors from the board's **3V3** pin.
+
+```
+ESP32-S3-DevKitC-1          I2C Sensor
+──────────────────          ──────────
+3V3  ──────────────────────  VCC / VIN
+GND  ──────────────────────  GND
+GPIO8 (SDA) ───────────────  SDA
+GPIO9 (SCL) ───────────────  SCL
+```
+
+### Supported Sensors
+
+| Sensor | Default I2C Address | Address Select |
+|--------|--------------------|-|
+| BME280 (temp / humidity / pressure) | 0x76 | SDO → GND = 0x76, SDO → 3V3 = 0x77 |
+| BMP280 (temp / pressure) | 0x76 | SDO → GND = 0x76, SDO → 3V3 = 0x77 |
+| MPU-6050 (accel / gyro) | 0x68 | AD0 → GND = 0x68, AD0 → 3V3 = 0x69 |
+| ADS1115 (16-bit ADC) | 0x48 | ADDR: GND=0x48, VCC=0x49, SDA=0x4A, SCL=0x4B |
+| SHT31 (temp / humidity) | 0x44 | ADDR → GND = 0x44, ADDR → 3V3 = 0x45 |
+| BH1750 (ambient light) | 0x23 | ADDR → GND = 0x23, ADDR → 3V3 = 0x5C |
+| INA219 (current / voltage) | 0x40 | A0/A1 → GND = 0x40 … see datasheet for others |
+
+Multiple sensors can be connected simultaneously using the same SDA/SCL lines,
+provided each sensor has a unique address.
+
+## CAN Bus Wiring (optional)
+
+Requires a 3.3 V-compatible CAN transceiver such as the **SN65HVD230** or
+**TJA1051T/3**.  Do **not** use 5 V-only transceivers (e.g. MCP2551) directly.
+
+```
+ESP32-S3-DevKitC-1          SN65HVD230 transceiver        CAN Bus
+──────────────────          ──────────────────────         ───────
+3V3  ──────────────────────  VCC (3.3 V)
+GND  ──────────────────────  GND
+GPIO4 (CAN TX) ─────────────  TXD
+GPIO5 (CAN RX) ─────────────  RXD
+                              CANH ─────────────────────── CANH
+                              CANL ─────────────────────── CANL
+```
+
+Add 120 Ω termination resistors at each end of the CAN bus if the cable is
+longer than ~0.5 m.
+
+## UART Serial Wiring (NMEA 0183 / GPS)
+
+```
+ESP32-S3-DevKitC-1          Serial Device (e.g. GPS module)
+──────────────────          ──────────────────────────────
+GND  ──────────────────────  GND
+GPIO17 (UART1 TX) ──────────  RX
+GPIO16 (UART1 RX) ──────────  TX
+```
+
+## Build Configuration
+
+```ini
+# platformio.ini
+[env:esp32-s3-devkitc-1]
+platform  = espressif32
+board     = esp32-s3-devkitc-1
+framework = arduino
+build_flags =
+    -std=gnu++17
+    -D BOARD_ESP32_S3_DEVKITC1
+```
+
+## Notes
+
+- **LED**: GPIO48 drives a WS2812B RGB LED (not a plain GPIO).  Use the
+  `Adafruit_NeoPixel` or FastLED library to control it.
+- **Strapping pins**: GPIO0, GPIO3, GPIO45, GPIO46 have special boot functions.
+  Avoid using them unless you understand the implications.
+- **PSRAM**: The N8R8 variant has 8 MB PSRAM wired internally via Octal-SPI —
+  no user pins are consumed.

--- a/docs/boards/m5stack-core.md
+++ b/docs/boards/m5stack-core.md
@@ -1,0 +1,123 @@
+# M5Stack Core ESP32
+
+## Overview
+
+| Item | Value |
+|------|-------|
+| Chip | ESP32 (dual-core Xtensa LX6 @ 240 MHz) |
+| Flash | 16 MB |
+| PSRAM | None (Basic) / 4 MB (Gray/Fire variants) |
+| Connectivity | 2.4 GHz WiFi 4 + Bluetooth 4.2 + BLE |
+| Display | 2" IPS LCD 320×240 (ILI9342C, SPI) |
+| Sensors (internal) | 6-axis IMU (SH200Q or MPU6886 depending on variant) |
+| Storage | MicroSD card slot (SPI, shared with LCD) |
+| USB | USB-C via CP2104 UART bridge |
+| Battery | 110 mAh LiPo with IP5306 management IC |
+| MCP transport | Full (WebSocket + mDNS + UDP discovery) |
+| PlatformIO env | `m5stack-core` |
+| Where to buy | [M5Stack Official Store](https://shop.m5stack.com), Amazon, AliExpress |
+
+## GPIO Conflict Map
+
+Many GPIO pins are committed to internal hardware.  **Read this before wiring
+external sensors.**
+
+| GPIO | Internal function | Available for external use? |
+|------|------------------|-----------------------------|
+| 1 | UART0 TX (USB-CP2104) | Yes (debug only) |
+| 3 | UART0 RX (USB-CP2104) | Yes (debug only) |
+| 4 | SD card CS | No |
+| 12 | SD MISO | No |
+| 13 | Speaker output (DAC) | No |
+| 14 | LCD DC | No |
+| 15 | SD CLK | No |
+| 16 | Grove Port C RX | Yes |
+| 17 | Grove Port C TX | Yes |
+| 18 | LCD CLK / SD CLK | No |
+| 19 | SD MISO | No |
+| 21 | I2C SDA (Grove A + IMU) | Yes — shared |
+| 22 | I2C SCL (Grove A + IMU) | Yes — shared |
+| 23 | LCD MOSI / SD MOSI | No |
+| 25 | Speaker DAC | No |
+| 26 | Grove Port B I/O | Yes |
+| 27 | LCD RST | No |
+| 33 | LCD CS / Grove A power | No |
+| 34 | Microphone ADC | Input only |
+| 35 | Battery ADC | Input only |
+| 36 | Button C | Input only |
+| 37 | Button B | Input only |
+| 38 | Button A | Input only |
+| 39 | IMU interrupt | Input only |
+
+## I2C Sensor Wiring
+
+External I2C sensors connect to **Grove Port A** (the red 4-pin HY2.0 socket
+on the side of the unit).  The bus is shared with the onboard IMU, so address
+conflicts with the IMU (0x68 / 0x6C) must be avoided.
+
+```
+M5Stack Core                 I2C Sensor            Grove Port A
+────────────                 ──────────             ────────────
+3V3  ───────────────────────  VCC / VIN  ──────────  pin 1 (red)
+GND  ───────────────────────  GND        ──────────  pin 2 (black)
+GPIO21 (SDA) ───────────────  SDA        ──────────  pin 3 (yellow)
+GPIO22 (SCL) ───────────────  SCL        ──────────  pin 4 (white)
+```
+
+You can use a standard HY2.0 4-pin → Dupont adapter (widely sold) to connect
+breakout boards directly to Grove Port A.
+
+### Supported Sensors
+
+| Sensor | Default I2C Address | Address Select | IMU conflict? |
+|--------|--------------------|-|-----|
+| BME280 | 0x76 | SDO → GND = 0x76 | No |
+| BMP280 | 0x76 | SDO → GND = 0x76 | No |
+| MPU-6050 | 0x68 | AD0 → GND = 0x68 | **Yes** (0x68 = IMU address) |
+| ADS1115 | 0x48 | — | No |
+| SHT31 | 0x44 | — | No |
+| BH1750 | 0x23 | — | No |
+| INA219 | 0x40 | — | No |
+
+> If MPU-6050 is needed, set AD0 → 3V3 (address 0x69) to avoid conflict with
+> the onboard IMU.
+
+## UART Serial Wiring (NMEA 0183 / GPS)
+
+Connect to **Grove Port C** (blue connector, bottom face).
+
+```
+M5Stack Core                 Serial Device         Grove Port C
+────────────                 ─────────────          ────────────
+GND  ───────────────────────  GND        ──────────  pin 2 (black)
+GPIO17 (TX) ────────────────  RX         ──────────  pin 3 (yellow)
+GPIO16 (RX) ────────────────  TX         ──────────  pin 4 (white)
+```
+
+## CAN Bus Wiring
+
+CAN is not natively accessible on M5Stack's standard Grove ports; GPIO5 and
+GPIO4 (typical TWAI pins) are not broken out.  Use a custom connector or the
+M5Stack Bus expansion headers on the bottom.
+
+## Build Configuration
+
+```ini
+[env:m5stack-core]
+platform  = espressif32
+board     = m5stack-core-esp32
+framework = arduino
+build_flags =
+    -std=gnu++17
+    -D BOARD_M5STACK_CORE
+```
+
+## Notes
+
+- **Display**: The LCD uses the ILI9342C SPI driver.  If you add display
+  support, use the `M5Stack` or `M5Unified` library; do not share the SPI bus
+  with external devices.
+- **Power button**: Hold for 6 seconds to power off.  A short press wakes from
+  deep sleep.
+- **Basic vs Gray/Fire**: The Gray variant adds PSRAM; the Fire uses a different
+  power management IC.  All three share the same GPIO map for I2C and UART.

--- a/docs/boards/nrf52840-dk.md
+++ b/docs/boards/nrf52840-dk.md
@@ -1,0 +1,106 @@
+# Nordic nRF52840-DK
+
+## Overview
+
+| Item | Value |
+|------|-------|
+| Chip | nRF52840 (ARM Cortex-M4F @ 64 MHz) |
+| Flash | 1 MB |
+| RAM | 256 KB |
+| Connectivity | Bluetooth 5.0 LE + 802.15.4 (Thread, Zigbee) |
+| USB | USB-C (USB CDC + J-Link OB debugger) |
+| MCP transport | **Sensor-only** — no built-in WiFi |
+| PlatformIO env | `nrf52840-dk` |
+| Where to buy | [Nordic Store](https://www.nordicsemi.com/Products/Development-hardware/nRF52840-DK), Mouser, DigiKey |
+
+### WiFi Limitations
+
+The nRF52840 does not have an integrated WiFi radio.  This build compiles the
+**sensor acquisition layer only**: I2C sensors are scanned and readings are
+printed to Serial (USB CDC).
+
+To enable full MCP-over-WiFi you have two options:
+
+1. **External ESP32-C3 AT-command WiFi module** — connect via UART1 (TX=6 /
+   RX=8) and bridge the JSON-RPC stream using the ESP-AT firmware.
+2. **BLE transport** (future) — expose the MCP JSON-RPC API as a BLE GATT
+   service using the onboard nRF52840 BLE stack.
+
+## Pinout Reference
+
+```
+                    nRF52840-DK (Arduino header side)
+              ┌──────────────────────────────┐
+  VDD  ──── │ VDD                 5V       │ ──── 5V (USB)
+  GND  ──── │ GND                 GND      │ ──── GND
+             │ P0.02 / A0          P0.26    │ ──── I2C SDA
+             │ P0.03 / A1          P0.27    │ ──── I2C SCL
+             │ P0.04 / A2          P1.01    │
+             │ P0.05 / A3          P1.02    │
+             │ P0.28 / A4          P1.03    │
+             │ P0.29 / A5          P1.04    │
+             │ P0.31 / A6          P1.05    │
+             │ P0.02 / A7          P1.06    │
+             │ P0.06 (TX1) ←       P1.07    │
+             │ P0.08 (RX1) →       P1.08    │
+             │ P1.09               P1.10    │
+             │ P0.13 (LED1)        P0.14 (LED2) │
+              └──────────────────────────────┘
+```
+
+> Full schematic: https://infocenter.nordicsemi.com/topic/ug_nrf52840_dk/UG/dk/hw_description.html
+
+## I2C Sensor Wiring
+
+```
+nRF52840-DK                  I2C Sensor
+───────────                  ──────────
+VDD (3.3 V) ────────────────  VCC / VIN
+GND  ────────────────────────  GND
+P0.26 (SDA) ─────────────────  SDA
+P0.27 (SCL) ─────────────────  SCL
+```
+
+### Supported Sensors
+
+| Sensor | Default I2C Address | Address Select |
+|--------|--------------------|-|
+| BME280 (temp / humidity / pressure) | 0x76 | SDO → GND = 0x76, SDO → VDD = 0x77 |
+| BMP280 (temp / pressure) | 0x76 | SDO → GND = 0x76, SDO → VDD = 0x77 |
+| MPU-6050 (accel / gyro) | 0x68 | AD0 → GND = 0x68, AD0 → VDD = 0x69 |
+| ADS1115 (16-bit ADC) | 0x48 | ADDR: GND=0x48, VCC=0x49, SDA=0x4A, SCL=0x4B |
+| SHT31 (temp / humidity) | 0x44 | ADDR → GND = 0x44, ADDR → VDD = 0x45 |
+| BH1750 (ambient light) | 0x23 | ADDR → GND = 0x23, ADDR → VDD = 0x5C |
+| INA219 (current / voltage) | 0x40 | A0/A1 → GND = 0x40 … see datasheet |
+
+> The nRF52840-DK supplies **3.3 V** on VDD.  Confirm your sensor module
+> accepts 3.3 V before connecting (most modern breakouts do).
+
+## Serial Output
+
+Sensor readings are printed to USB CDC Serial at 115200 baud.  Connect with
+any serial terminal (e.g. `pio device monitor -e nrf52840-dk`).
+
+## Build Configuration
+
+```ini
+[env:nrf52840-dk]
+platform  = nordicnrf52
+board     = nordic_pca10056
+framework = arduino
+build_flags =
+    -std=gnu++17
+    -D BOARD_NRF52840_DK
+```
+
+## Notes
+
+- **LED polarity**: LEDs on the DK are **active LOW** — write `LOW` to turn
+  on, `HIGH` to turn off.
+- **VDD vs 3V3**: The DK header labelled VDD supplies 3.3 V when powered via
+  USB.  The 5V pin is USB VBUS.
+- **J-Link**: The onboard J-Link OB debugger allows single-step debugging with
+  VS Code + Cortex-Debug or Ozone.  No extra hardware is needed.
+- **SoftDevice**: PlatformIO's `nordicnrf52` platform does not automatically
+  flash a SoftDevice.  If you add BLE support later, ensure the correct
+  SoftDevice is programmed.

--- a/docs/boards/nrf52840-feather.md
+++ b/docs/boards/nrf52840-feather.md
@@ -1,0 +1,105 @@
+# Adafruit Feather nRF52840
+
+## Overview
+
+| Item | Value |
+|------|-------|
+| Chip | nRF52840 (ARM Cortex-M4F @ 64 MHz) |
+| Flash | 1 MB |
+| RAM | 256 KB |
+| Connectivity | Bluetooth 5.0 LE + 802.15.4 |
+| USB | USB-C (native USB CDC via nRF52840; no bridge chip) |
+| LiPo charging | Yes — JST 2-pin connector with onboard charger |
+| Form factor | Adafruit Feather (compatible with FeatherWings) |
+| MCP transport | **Sensor-only** — no built-in WiFi |
+| PlatformIO env | `nrf52840-feather` |
+| Where to buy | [Adafruit #4062](https://www.adafruit.com/product/4062), Amazon, Digi-Key |
+
+### WiFi Limitations
+
+See [nrf52840-dk.md](nrf52840-dk.md) for the WiFi bridging options.  This board
+uses the same nRF52840 SoC, so the same workarounds apply.
+
+## Pinout Reference
+
+```
+              Adafruit Feather nRF52840
+          ┌─────────────────────────────┐
+  RST ─── │ RST                  BAT  │ ── LiPo+
+  3V3 ─── │ 3V3                  EN   │
+  GND ─── │ GND                  USB  │ ── 5V USB
+  A0  ─── │ P0.04 / A0           GND  │ ── GND
+  A1  ─── │ P0.05 / A1           P1.02│
+  A2  ─── │ P0.30 / A2           P1.01│
+  A3  ─── │ P0.28 / A3           P0.27│
+  A4  ─── │ P0.02 / A4           P0.26│
+  A5  ─── │ P0.03 / A5           P0.06│
+  SCK ─── │ P0.14                P0.25│ ── UART TX
+  MO  ─── │ P0.13                P0.24│ ── UART RX
+  MI  ─── │ P0.15                P0.12│ ── I2C SDA
+  RX  ─── │ P0.24 (RX)           P0.11│ ── I2C SCL
+  TX  ─── │ P0.25 (TX)           P1.10│ ── Blue LED
+  SDA ─── │ P0.12 (SDA)          P1.09│ ── Red LED
+  SCL ─── │ P0.11 (SCL)               │
+          └─────────────────────────────┘
+```
+
+> Full pinout: https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/pinouts
+
+## I2C Sensor Wiring
+
+SDA and SCL are clearly labelled on the Feather silkscreen; a STEMMA QT /
+Qwiic compatible header is also available on some revisions.
+
+```
+Adafruit nRF52840 Feather     I2C Sensor
+────────────────────────      ──────────
+3V3  ─────────────────────── VCC / VIN
+GND  ─────────────────────── GND
+P0.12 / SDA ─────────────── SDA
+P0.11 / SCL ─────────────── SCL
+```
+
+### Supported Sensors
+
+| Sensor | Default I2C Address | Address Select |
+|--------|--------------------|-|
+| BME280 (temp / humidity / pressure) | 0x76 | SDO → GND = 0x76, SDO → 3V3 = 0x77 |
+| BMP280 (temp / pressure) | 0x76 | SDO → GND = 0x76, SDO → 3V3 = 0x77 |
+| MPU-6050 (accel / gyro) | 0x68 | AD0 → GND = 0x68, AD0 → 3V3 = 0x69 |
+| ADS1115 (16-bit ADC) | 0x48 | ADDR: GND=0x48, VCC=0x49, SDA=0x4A, SCL=0x4B |
+| SHT31 (temp / humidity) | 0x44 | ADDR → GND = 0x44, ADDR → 3V3 = 0x45 |
+| BH1750 (ambient light) | 0x23 | ADDR → GND = 0x23, ADDR → 3V3 = 0x5C |
+| INA219 (current / voltage) | 0x40 | A0/A1 → GND = 0x40 … see datasheet |
+
+## Serial Output
+
+Sensor readings are printed to USB CDC Serial at 115200 baud:
+
+```
+pio device monitor -e nrf52840-feather
+```
+
+## Build Configuration
+
+```ini
+[env:nrf52840-feather]
+platform  = nordicnrf52
+board     = adafruit_feather_nrf52840
+framework = arduino
+build_flags =
+    -std=gnu++17
+    -D BOARD_NRF52840_FEATHER
+```
+
+## Notes
+
+- **LED polarity**: Both the red LED (P1.09) and blue LED (P1.10) are
+  **active LOW**.  `LED_RED` and `LED_BLUE` are defined by the Adafruit nRF52
+  Arduino core.
+- **Battery**: Use the `analogRead(PIN_VBAT)` with the `VBAT_MV_PER_LSB`
+  constant from the Adafruit BSP to read battery voltage.
+- **Bootloader**: The board ships with the Adafruit nRF52 USB DFU bootloader.
+  PlatformIO uploads over USB automatically.
+- **SoftDevice**: The Adafruit BSP includes SoftDevice S140 for BLE support;
+  it is loaded automatically when using `nordicnrf52` platform.

--- a/include/SensorManager.h
+++ b/include/SensorManager.h
@@ -6,7 +6,9 @@
 #include <functional>
 #include <map>
 #include <memory>
+#ifndef MCP_NO_THREADS
 #include <mutex>
+#endif
 #include <string>
 #include <vector>
 
@@ -69,7 +71,9 @@ private:
     std::vector<I2CDevice>                         devices_;
     std::vector<std::unique_ptr<I2CSensorDriver>>  drivers_;
 
+#ifndef MCP_NO_THREADS
     mutable std::mutex mutex_;
+#endif
 
     // Map sensorId -> index in drivers_ for fast lookup
     std::map<std::string, size_t> driverIndex_;

--- a/include/board_config.h
+++ b/include/board_config.h
@@ -1,0 +1,45 @@
+#pragma once
+// ─── Board Configuration Selector ────────────────────────────────────────────
+// Selects the correct per-board pin/capability header based on the BOARD_*
+// macro defined by the PlatformIO build_flags for the active environment.
+//
+// Usage — add exactly one of the following to the relevant [env] in
+// platformio.ini (already done; shown here for reference only):
+//
+//   -D BOARD_ESP32_S3_DEVKITC1      ESP32-S3-DevKitC-1 (default)
+//   -D BOARD_ESP32_DEVKITC          ESP32 DevKitC V4
+//   -D BOARD_ESP32_C3_DEVKITM1      ESP32-C3-DevKitM-1
+//   -D BOARD_ADAFRUIT_HUZZAH32      Adafruit HUZZAH32 ESP32 Feather
+//   -D BOARD_M5STACK_CORE           M5Stack Core ESP32
+//   -D BOARD_NRF52840_DK            Nordic nRF52840-DK
+//   -D BOARD_NRF52840_FEATHER       Adafruit Feather nRF52840
+//
+// Each header defines:
+//   BOARD_NAME, BOARD_VARIANT, BOARD_HAS_WIFI, BOARD_HAS_BLE, BOARD_HAS_CAN
+//   BOARD_I2C_SDA, BOARD_I2C_SCL, BOARD_I2C_FREQ
+//   BOARD_UART_TX, BOARD_UART_RX, BOARD_UART1_TX, BOARD_UART1_RX
+//   BOARD_LED_PIN, BOARD_LED_RGB
+//   BOARD_CAN_TX, BOARD_CAN_RX  (ESP32 only)
+//   BOARD_SERIAL_BAUD, BOARD_MCP_PORT, BOARD_HTTP_PORT
+
+#if defined(BOARD_ESP32_S3_DEVKITC1)
+#  include "boards/board_esp32_s3_devkitc1.h"
+#elif defined(BOARD_ESP32_DEVKITC)
+#  include "boards/board_esp32_devkitc.h"
+#elif defined(BOARD_ESP32_C3_DEVKITM1)
+#  include "boards/board_esp32_c3_devkitm1.h"
+#elif defined(BOARD_ADAFRUIT_HUZZAH32)
+#  include "boards/board_adafruit_huzzah32.h"
+#elif defined(BOARD_M5STACK_CORE)
+#  include "boards/board_m5stack_core.h"
+#elif defined(BOARD_NRF52840_DK)
+#  include "boards/board_nrf52840_dk.h"
+#elif defined(BOARD_NRF52840_FEATHER)
+#  include "boards/board_nrf52840_feather.h"
+#else
+// ── Default: ESP32-S3-DevKitC-1 ─────────────────────────────────────────────
+// No BOARD_* flag was set; fall back to the original target for backwards
+// compatibility with existing builds that predate per-board configs.
+#  include "boards/board_esp32_s3_devkitc1.h"
+#  define BOARD_ESP32_S3_DEVKITC1   // set so downstream #ifdef checks work
+#endif

--- a/include/boards/board_adafruit_huzzah32.h
+++ b/include/boards/board_adafruit_huzzah32.h
@@ -1,0 +1,41 @@
+#pragma once
+// ─── Adafruit HUZZAH32 ESP32 Feather ─────────────────────────────────────────
+// Feather form-factor board with ESP32 module, JST LiPo connector and charger.
+// Compatible with Feather Wings.  CP2104 USB-UART bridge.
+// https://learn.adafruit.com/adafruit-huzzah32-esp32-feather
+
+#define BOARD_NAME          "Adafruit HUZZAH32 ESP32 Feather"
+#define BOARD_VARIANT       "esp32"
+#define BOARD_HAS_WIFI      1
+#define BOARD_HAS_BLE       1
+#define BOARD_HAS_CAN       1   // TWAI via external transceiver
+
+// ── I2C ──────────────────────────────────────────────────────────────────────
+// SDA and SCL are clearly labelled on the board silkscreen.
+#define BOARD_I2C_SDA       23
+#define BOARD_I2C_SCL       22
+#define BOARD_I2C_FREQ      400000UL
+
+// ── UART ─────────────────────────────────────────────────────────────────────
+#define BOARD_UART_TX       1    // USB-UART via CP2104
+#define BOARD_UART_RX       3
+#define BOARD_UART1_TX      17
+#define BOARD_UART1_RX      16
+
+// ── Status LED ───────────────────────────────────────────────────────────────
+#define BOARD_LED_PIN       13   // Red LED, active HIGH
+#define BOARD_LED_RGB       0
+
+// ── Battery monitor ──────────────────────────────────────────────────────────
+// ADC pin connected to the LiPo battery through a voltage divider (÷2).
+// Read voltage: analogRead(BOARD_VBAT_PIN) * 2 * 3.3 / 4095
+#define BOARD_VBAT_PIN      35   // A13 / GPIO35
+
+// ── CAN / TWAI ───────────────────────────────────────────────────────────────
+#define BOARD_CAN_TX        4
+#define BOARD_CAN_RX        5
+
+// ── Misc ─────────────────────────────────────────────────────────────────────
+#define BOARD_SERIAL_BAUD   115200
+#define BOARD_MCP_PORT      9000
+#define BOARD_HTTP_PORT     80

--- a/include/boards/board_esp32_c3_devkitm1.h
+++ b/include/boards/board_esp32_c3_devkitm1.h
@@ -1,0 +1,40 @@
+#pragma once
+// ─── ESP32-C3-DevKitM-1 ──────────────────────────────────────────────────────
+// Espressif RISC-V based ESP32-C3 development board — low-cost, low-power IoT.
+// Single-core RISC-V @ 160 MHz, 4 MB flash, 2.4 GHz WiFi + BLE 5.0.
+// Native USB-Serial/JTAG; no external UART bridge chip required.
+// https://docs.espressif.com/projects/esp-idf/en/stable/esp32c3/hw-reference/esp32c3/user-guide-devkitm-1.html
+
+#define BOARD_NAME          "ESP32-C3-DevKitM-1"
+#define BOARD_VARIANT       "esp32c3"
+#define BOARD_HAS_WIFI      1
+#define BOARD_HAS_BLE       1   // BLE 5.0 (no Classic BT)
+#define BOARD_HAS_CAN       1   // TWAI
+
+// ── I2C ──────────────────────────────────────────────────────────────────────
+// NOTE: GPIO8 carries the onboard WS2812B RGB LED on this board.
+// GPIO5/GPIO6 are chosen to avoid that conflict.
+#define BOARD_I2C_SDA       5
+#define BOARD_I2C_SCL       6
+#define BOARD_I2C_FREQ      400000UL
+
+// ── UART ─────────────────────────────────────────────────────────────────────
+// UART0 is routed through the built-in USB Serial/JTAG peripheral.
+// UART1 on GPIO7/GPIO10 for external serial devices.
+#define BOARD_UART_TX       21   // USB-Serial/JTAG
+#define BOARD_UART_RX       20
+#define BOARD_UART1_TX      7
+#define BOARD_UART1_RX      10
+
+// ── Status LED ───────────────────────────────────────────────────────────────
+#define BOARD_LED_PIN       8    // WS2812B RGB LED
+#define BOARD_LED_RGB       1
+
+// ── CAN / TWAI ───────────────────────────────────────────────────────────────
+#define BOARD_CAN_TX        3
+#define BOARD_CAN_RX        2
+
+// ── Misc ─────────────────────────────────────────────────────────────────────
+#define BOARD_SERIAL_BAUD   115200
+#define BOARD_MCP_PORT      9000
+#define BOARD_HTTP_PORT     80

--- a/include/boards/board_esp32_devkitc.h
+++ b/include/boards/board_esp32_devkitc.h
@@ -1,0 +1,38 @@
+#pragma once
+// ─── ESP32 DevKitC V4 ────────────────────────────────────────────────────────
+// Espressif classic development board with ESP32-WROOM-32 module.
+// Dual-core Xtensa LX6 @ 240 MHz, 4 MB flash, 2.4 GHz WiFi + BT/BLE.
+// Most widely available ESP32 form factor; sold under many vendor names.
+// https://docs.espressif.com/projects/esp-idf/en/stable/esp32/hw-reference/esp32/get-started-devkitc.html
+
+#define BOARD_NAME          "ESP32 DevKitC V4"
+#define BOARD_VARIANT       "esp32"
+#define BOARD_HAS_WIFI      1
+#define BOARD_HAS_BLE       1   // Bluetooth Classic 4.2 + BLE
+#define BOARD_HAS_CAN       1   // TWAI peripheral
+
+// ── I2C (Arduino Wire defaults for classic ESP32) ────────────────────────────
+#define BOARD_I2C_SDA       21
+#define BOARD_I2C_SCL       22
+#define BOARD_I2C_FREQ      400000UL
+
+// ── UART ─────────────────────────────────────────────────────────────────────
+// UART0 is connected to the onboard CP2102/CH340 USB-UART bridge.
+// UART2 is available for external peripherals.
+#define BOARD_UART_TX       1    // UART0 TX (USB bridge)
+#define BOARD_UART_RX       3    // UART0 RX (USB bridge)
+#define BOARD_UART1_TX      17   // UART2 TX (external devices)
+#define BOARD_UART1_RX      16   // UART2 RX
+
+// ── Status LED ───────────────────────────────────────────────────────────────
+#define BOARD_LED_PIN       2    // Blue LED, active HIGH
+#define BOARD_LED_RGB       0
+
+// ── CAN / TWAI ───────────────────────────────────────────────────────────────
+#define BOARD_CAN_TX        5
+#define BOARD_CAN_RX        4
+
+// ── Misc ─────────────────────────────────────────────────────────────────────
+#define BOARD_SERIAL_BAUD   115200
+#define BOARD_MCP_PORT      9000
+#define BOARD_HTTP_PORT     80

--- a/include/boards/board_esp32_s3_devkitc1.h
+++ b/include/boards/board_esp32_s3_devkitc1.h
@@ -1,0 +1,41 @@
+#pragma once
+// ─── ESP32-S3-DevKitC-1 ──────────────────────────────────────────────────────
+// Espressif official development board with ESP32-S3-WROOM-1 module.
+// Dual-core Xtensa LX7 @ 240 MHz, 8 MB PSRAM (N8R8 variant), 16 MB flash,
+// native USB (OTG + JTAG/CDC), 2.4 GHz WiFi + BLE 5.0.
+// https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html
+
+#define BOARD_NAME          "ESP32-S3-DevKitC-1"
+#define BOARD_VARIANT       "esp32s3"
+#define BOARD_HAS_WIFI      1
+#define BOARD_HAS_BLE       1
+#define BOARD_HAS_CAN       1   // TWAI peripheral (ISO 11898-1 compatible)
+
+// ── I2C (Arduino Wire defaults for ESP32-S3) ─────────────────────────────────
+#define BOARD_I2C_SDA       8
+#define BOARD_I2C_SCL       9
+#define BOARD_I2C_FREQ      400000UL
+
+// ── UART ─────────────────────────────────────────────────────────────────────
+// UART0 is routed through the on-chip USB JTAG/CDC bridge (no physical pins).
+// UART1 is available on the GPIO header for external bus devices (NMEA, etc.).
+#define BOARD_UART_TX       43   // USB-CDC / programming port
+#define BOARD_UART_RX       44
+#define BOARD_UART1_TX      17   // External serial (NMEA 0183, GPS, etc.)
+#define BOARD_UART1_RX      16
+
+// ── Status LED ───────────────────────────────────────────────────────────────
+// DevKitC-1 v1.4+ has a WS2812B RGB LED on GPIO48. Earlier revisions expose
+// a plain blue LED on GPIO2.  Set BOARD_LED_RGB=1 when using the WS2812.
+#define BOARD_LED_PIN       48
+#define BOARD_LED_RGB       1    // 1 = addressable WS2812B, 0 = plain GPIO
+
+// ── CAN / TWAI ───────────────────────────────────────────────────────────────
+// Requires an external 3.3 V CAN transceiver (e.g. SN65HVD230, TJA1050-3V3).
+#define BOARD_CAN_TX        4
+#define BOARD_CAN_RX        5
+
+// ── Misc ─────────────────────────────────────────────────────────────────────
+#define BOARD_SERIAL_BAUD   115200
+#define BOARD_MCP_PORT      9000
+#define BOARD_HTTP_PORT     80

--- a/include/boards/board_m5stack_core.h
+++ b/include/boards/board_m5stack_core.h
@@ -1,0 +1,48 @@
+#pragma once
+// ─── M5Stack Core ESP32 ──────────────────────────────────────────────────────
+// All-in-one ESP32 module with 2" IPS LCD, IMU, speaker, micro-SD, and
+// 3× Grove ports (A/B/C).  USB-C charging with onboard LiPo management.
+// https://docs.m5stack.com/en/core/basic_v2.6
+//
+// ⚠ Several GPIO pins are used internally by the LCD, SD card, and speaker.
+//   See the GPIO conflict table in docs/boards/m5stack-core.md before
+//   assigning any new peripherals.
+
+#define BOARD_NAME          "M5Stack Core ESP32"
+#define BOARD_VARIANT       "esp32"
+#define BOARD_HAS_WIFI      1
+#define BOARD_HAS_BLE       1
+#define BOARD_HAS_CAN       0   // No CAN on standard I/O; requires custom cable
+
+// ── I2C ──────────────────────────────────────────────────────────────────────
+// Grove Port A (red connector on the side) is the primary user I2C port.
+// Internal peripherals (IMU SH200Q/MPU6886) also share this bus.
+#define BOARD_I2C_SDA       21
+#define BOARD_I2C_SCL       22
+#define BOARD_I2C_FREQ      400000UL
+
+// ── UART ─────────────────────────────────────────────────────────────────────
+// Grove Port C (blue, bottom) is UART.  Port A overrides if I2C is in use.
+#define BOARD_UART_TX       1    // USB-UART via CP2104
+#define BOARD_UART_RX       3
+#define BOARD_UART1_TX      17   // Grove Port C TX
+#define BOARD_UART1_RX      16   // Grove Port C RX
+
+// ── Status LED ───────────────────────────────────────────────────────────────
+// No simple user LED; use the LCD or the small power RGB on the side.
+#define BOARD_LED_PIN       (-1)
+#define BOARD_LED_RGB       0
+
+// ── Internal GPIO map (informational — do not reassign) ──────────────────────
+// GPIO23 = LCD MOSI / SD MOSI     GPIO18 = LCD SCK / SD SCK
+// GPIO14 = LCD DC                 GPIO27 = LCD RST
+// GPIO33 = LCD CS                 GPIO4  = SD CS
+// GPIO25 = speaker DAC out        GPIO34 = Mic ADC (input only)
+// GPIO35 = battery ADC (input)    GPIO36 = button C input
+// GPIO37 = button B input         GPIO38 = button A input
+// GPIO39 = IMU interrupt (input)
+
+// ── Misc ─────────────────────────────────────────────────────────────────────
+#define BOARD_SERIAL_BAUD   115200
+#define BOARD_MCP_PORT      9000
+#define BOARD_HTTP_PORT     80

--- a/include/boards/board_nrf52840_dk.h
+++ b/include/boards/board_nrf52840_dk.h
@@ -24,31 +24,21 @@
 // ── I2C ──────────────────────────────────────────────────────────────────────
 // Arduino Wire on nRF52 uses the pins defined by the board variant.
 // nRF52840-DK default: P0.26 = SDA, P0.27 = SCL.
-// The macros SDA / SCL are provided by the nordicnrf52 platform variant; the
-// fallback values below match the DK schematic in case they are not defined.
-#ifndef SDA
-#  define SDA 26
-#endif
-#ifndef SCL
-#  define SCL 27
-#endif
-#define BOARD_I2C_SDA       SDA
-#define BOARD_I2C_SCL       SCL
+// Do NOT define SDA/SCL as macros here — nrf52.h has struct members with
+// those names and the preprocessor would clobber them.
+#define BOARD_I2C_SDA       26
+#define BOARD_I2C_SCL       27
 #define BOARD_I2C_FREQ      400000UL
 
 // ── UART ─────────────────────────────────────────────────────────────────────
 // Serial is USB CDC (no physical pins needed).
-// Serial1 is on the Arduino header; TX and RX macros come from the variant.
-#ifndef TX
-#  define TX 6   // P0.06
-#endif
-#ifndef RX
-#  define RX 8   // P0.08
-#endif
-#define BOARD_UART_TX       TX
-#define BOARD_UART_RX       RX
-#define BOARD_UART1_TX      TX
-#define BOARD_UART1_RX      RX
+// Serial1 is on the Arduino header; P0.06 = TX, P0.08 = RX.
+// TX and RX are also struct-member names in the nRF52 SDK; define only the
+// BOARD_ aliases to avoid clashes.
+#define BOARD_UART_TX       6    // P0.06
+#define BOARD_UART_RX       8    // P0.08
+#define BOARD_UART1_TX      6
+#define BOARD_UART1_RX      8
 
 // ── Status LED ───────────────────────────────────────────────────────────────
 // LED1–LED4 are active LOW on the nRF52840-DK.

--- a/include/boards/board_nrf52840_dk.h
+++ b/include/boards/board_nrf52840_dk.h
@@ -1,0 +1,62 @@
+#pragma once
+// ─── Nordic nRF52840-DK ──────────────────────────────────────────────────────
+// Official Nordic Semiconductor development kit for nRF52840 SoC.
+// ARM Cortex-M4F @ 64 MHz, 1 MB flash, 256 KB RAM, BLE 5.0 + 802.15.4.
+// J-Link OB debugger onboard, Arduino-compatible header, USB-C.
+// https://www.nordicsemi.com/Products/Development-hardware/nRF52840-DK
+//
+// Platform: nordicnrf52   Board ID: nordic_pca10056
+//
+// ⚠ No built-in WiFi.  WiFi-dependent features (WebSocket MCP server, mDNS,
+//   UDP broadcast) are NOT compiled for this target.  This build provides:
+//     • I2C sensor acquisition (SensorManager, I2CSensors)
+//     • Metrics collection (MetricsSystem)
+//     • Serial output of sensor readings
+//   For full MCP-over-WiFi, attach an external ESP32-C3 in AT-command mode
+//   to UART1 (TX=6 / RX=8) and bridge the JSON-RPC stream.
+
+#define BOARD_NAME          "Nordic nRF52840-DK"
+#define BOARD_VARIANT       "nrf52840"
+#define BOARD_HAS_WIFI      0
+#define BOARD_HAS_BLE       1   // Bluetooth 5.0 LE + 802.15.4
+#define BOARD_HAS_CAN       0
+
+// ── I2C ──────────────────────────────────────────────────────────────────────
+// Arduino Wire on nRF52 uses the pins defined by the board variant.
+// nRF52840-DK default: P0.26 = SDA, P0.27 = SCL.
+// The macros SDA / SCL are provided by the nordicnrf52 platform variant; the
+// fallback values below match the DK schematic in case they are not defined.
+#ifndef SDA
+#  define SDA 26
+#endif
+#ifndef SCL
+#  define SCL 27
+#endif
+#define BOARD_I2C_SDA       SDA
+#define BOARD_I2C_SCL       SCL
+#define BOARD_I2C_FREQ      400000UL
+
+// ── UART ─────────────────────────────────────────────────────────────────────
+// Serial is USB CDC (no physical pins needed).
+// Serial1 is on the Arduino header; TX and RX macros come from the variant.
+#ifndef TX
+#  define TX 6   // P0.06
+#endif
+#ifndef RX
+#  define RX 8   // P0.08
+#endif
+#define BOARD_UART_TX       TX
+#define BOARD_UART_RX       RX
+#define BOARD_UART1_TX      TX
+#define BOARD_UART1_RX      RX
+
+// ── Status LED ───────────────────────────────────────────────────────────────
+// LED1–LED4 are active LOW on the nRF52840-DK.
+#define BOARD_LED_PIN       13   // LED1 = P0.13
+#define BOARD_LED_RGB       0
+#define BOARD_LED_ACTIVE    LOW
+
+// ── Misc ─────────────────────────────────────────────────────────────────────
+#define BOARD_SERIAL_BAUD   115200
+#define BOARD_MCP_PORT      9000   // reserved for future WiFi-module bridge
+#define BOARD_HTTP_PORT     80

--- a/include/boards/board_nrf52840_feather.h
+++ b/include/boards/board_nrf52840_feather.h
@@ -1,0 +1,53 @@
+#pragma once
+// ─── Adafruit Feather nRF52840 ────────────────────────────────────────────────
+// Feather form-factor board with nRF52840, USB-C, JST LiPo connector,
+// and onboard charger.  BLE 5.0 + 802.15.4.  Compatible with FeatherWings.
+// https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather
+//
+// Platform: nordicnrf52   Board ID: adafruit_feather_nrf52840
+//
+// ⚠ No built-in WiFi.  See board_nrf52840_dk.h for full capability notes.
+
+#define BOARD_NAME          "Adafruit Feather nRF52840"
+#define BOARD_VARIANT       "nrf52840"
+#define BOARD_HAS_WIFI      0
+#define BOARD_HAS_BLE       1   // Bluetooth 5.0 LE
+#define BOARD_HAS_CAN       0
+
+// ── I2C ──────────────────────────────────────────────────────────────────────
+// SDA and SCL are labelled on the Feather silkscreen.
+// Adafruit nRF52 Arduino core maps: SDA = P0.12, SCL = P0.11.
+// The SDA/SCL macros are defined by the Adafruit nRF52 platform variant.
+#ifndef SDA
+#  define SDA 25   // Adafruit nRF52 Arduino pin 25 → P0.12
+#endif
+#ifndef SCL
+#  define SCL 26   // Adafruit nRF52 Arduino pin 26 → P0.11
+#endif
+#define BOARD_I2C_SDA       SDA
+#define BOARD_I2C_SCL       SCL
+#define BOARD_I2C_FREQ      400000UL
+
+// ── UART ─────────────────────────────────────────────────────────────────────
+// Serial is USB CDC.  Serial1 maps to the Feather TX/RX pads.
+#ifndef TX
+#  define TX 25   // P0.25
+#endif
+#ifndef RX
+#  define RX 24   // P0.24
+#endif
+#define BOARD_UART_TX       TX
+#define BOARD_UART_RX       RX
+#define BOARD_UART1_TX      TX
+#define BOARD_UART1_RX      RX
+
+// ── Status LEDs ──────────────────────────────────────────────────────────────
+// Red LED and Blue LED both active LOW.
+#define BOARD_LED_PIN       LED_BLUE   // provided by Adafruit nRF52 core
+#define BOARD_LED_RGB       0
+#define BOARD_LED_ACTIVE    LOW
+
+// ── Misc ─────────────────────────────────────────────────────────────────────
+#define BOARD_SERIAL_BAUD   115200
+#define BOARD_MCP_PORT      9000
+#define BOARD_HTTP_PORT     80

--- a/include/boards/board_nrf52840_feather.h
+++ b/include/boards/board_nrf52840_feather.h
@@ -16,30 +16,21 @@
 
 // ── I2C ──────────────────────────────────────────────────────────────────────
 // SDA and SCL are labelled on the Feather silkscreen.
-// Adafruit nRF52 Arduino core maps: SDA = P0.12, SCL = P0.11.
-// The SDA/SCL macros are defined by the Adafruit nRF52 platform variant.
-#ifndef SDA
-#  define SDA 25   // Adafruit nRF52 Arduino pin 25 → P0.12
-#endif
-#ifndef SCL
-#  define SCL 26   // Adafruit nRF52 Arduino pin 26 → P0.11
-#endif
-#define BOARD_I2C_SDA       SDA
-#define BOARD_I2C_SCL       SCL
+// Adafruit nRF52 Arduino core maps: SDA = P0.12 (pin 25), SCL = P0.11 (pin 26).
+// Do NOT define SDA/SCL as macros — nrf52.h has struct members with those
+// names and the preprocessor would clobber them.
+#define BOARD_I2C_SDA       25   // Adafruit nRF52 Arduino pin 25 → P0.12
+#define BOARD_I2C_SCL       26   // Adafruit nRF52 Arduino pin 26 → P0.11
 #define BOARD_I2C_FREQ      400000UL
 
 // ── UART ─────────────────────────────────────────────────────────────────────
-// Serial is USB CDC.  Serial1 maps to the Feather TX/RX pads.
-#ifndef TX
-#  define TX 25   // P0.25
-#endif
-#ifndef RX
-#  define RX 24   // P0.24
-#endif
-#define BOARD_UART_TX       TX
-#define BOARD_UART_RX       RX
-#define BOARD_UART1_TX      TX
-#define BOARD_UART1_RX      RX
+// Serial is USB CDC.  Serial1 maps to the Feather TX/RX pads (P0.25/P0.24).
+// TX and RX are also struct-member names in the nRF52 SDK; define only the
+// BOARD_ aliases.
+#define BOARD_UART_TX       25   // P0.25
+#define BOARD_UART_RX       24   // P0.24
+#define BOARD_UART1_TX      25
+#define BOARD_UART1_RX      24
 
 // ── Status LEDs ──────────────────────────────────────────────────────────────
 // Red LED and Blue LED both active LOW.

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,7 +31,7 @@ framework = arduino
 monitor_speed = 115200
 lib_deps =
     bblanchon/ArduinoJson
-; Exclude WiFi-dependent sources; main_nrf.cpp is the entry point instead.
+; Exclude WiFi/LittleFS-dependent sources; main_nrf.cpp is the entry point instead.
 build_src_filter =
     +<*>
     -<main.cpp>
@@ -39,7 +39,9 @@ build_src_filter =
     -<DiscoveryManager.cpp>
     -<MCPServer.cpp>
     -<uLogger.cpp>
+    -<MetricsSystem.cpp>
     +<main_nrf.cpp>
+build_unflags = -std=gnu++11
 build_flags =
     -std=gnu++17
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -44,6 +44,7 @@ build_src_filter =
 build_unflags = -std=gnu++11
 build_flags =
     -std=gnu++17
+    -D MCP_NO_THREADS
 
 ; ─── ESP32 targets (full MCP server: WebSocket + mDNS + UDP discovery) ────────
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -84,7 +84,7 @@ build_flags =
 
 [env:nrf52840-dk]
 extends = nrf52_base
-board   = nordic_pca10056
+board   = nrf52840_dk
 build_flags =
     ${nrf52_base.build_flags}
     -D BOARD_NRF52840_DK

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,7 +1,13 @@
-[env:esp32-s3-devkitc-1]
-platform = espressif32
-board = esp32-s3-devkitc-1
+; ─── Shared base configurations ──────────────────────────────────────────────
+; Inherit with: extends = esp32_base  (or nrf52_base)
+; Override individual keys in the [env:*] section as needed.
+
+[esp32_base]
+platform  = espressif32
 framework = arduino
+monitor_speed = 115200
+board_build.filesystem = littlefs
+build_unflags = -std=gnu++11
 lib_deps =
     fastled/FastLED@3.9.7
     bblanchon/ArduinoJson
@@ -10,18 +16,85 @@ lib_deps =
     links2004/WebSockets@^2.6.1
     WiFi
     WiFiClientSecure
-monitor_speed = 115200
-board_build.filesystem = littlefs
-build_unflags = -std=gnu++11
-build_flags = 
+build_flags =
     -std=gnu++17
     -D CORE_DEBUG_LEVEL=5
     -D CONFIG_ASYNC_TCP_RUNNING_CORE=0
     -D WEBSOCKET_MAX_QUEUED_MESSAGES=32
     -D ASYNCWEBSERVER_REGEX=0
 
+[nrf52_base]
+platform  = nordicnrf52
+framework = arduino
+monitor_speed = 115200
+lib_deps =
+    bblanchon/ArduinoJson
+; Exclude WiFi-dependent sources; main_nrf.cpp is the entry point instead.
+build_src_filter =
+    +<*>
+    -<main.cpp>
+    -<NetworkManager.cpp>
+    -<DiscoveryManager.cpp>
+    -<MCPServer.cpp>
+    -<uLogger.cpp>
+    +<main_nrf.cpp>
+build_flags =
+    -std=gnu++17
 
+; ─── ESP32 targets (full MCP server: WebSocket + mDNS + UDP discovery) ────────
 
+[env:esp32-s3-devkitc-1]
+extends = esp32_base
+board   = esp32-s3-devkitc-1
+build_flags =
+    ${esp32_base.build_flags}
+    -D BOARD_ESP32_S3_DEVKITC1
+
+[env:esp32-devkitc]
+extends = esp32_base
+board   = esp32dev
+build_flags =
+    ${esp32_base.build_flags}
+    -D BOARD_ESP32_DEVKITC
+
+[env:esp32-c3-devkitm-1]
+extends = esp32_base
+board   = esp32-c3-devkitm-1
+build_flags =
+    ${esp32_base.build_flags}
+    -D BOARD_ESP32_C3_DEVKITM1
+
+[env:adafruit-huzzah32]
+extends = esp32_base
+board   = featheresp32
+build_flags =
+    ${esp32_base.build_flags}
+    -D BOARD_ADAFRUIT_HUZZAH32
+
+[env:m5stack-core]
+extends = esp32_base
+board   = m5stack-core-esp32
+build_flags =
+    ${esp32_base.build_flags}
+    -D BOARD_M5STACK_CORE
+
+; ─── nRF52840 targets (sensor acquisition only; no WiFi) ─────────────────────
+
+[env:nrf52840-dk]
+extends = nrf52_base
+board   = nordic_pca10056
+build_flags =
+    ${nrf52_base.build_flags}
+    -D BOARD_NRF52840_DK
+
+[env:nrf52840-feather]
+extends = nrf52_base
+board   = adafruit_feather_nrf52840
+build_flags =
+    ${nrf52_base.build_flags}
+    -D BOARD_NRF52840_FEATHER
+
+; ─── Native unit tests (no hardware) ─────────────────────────────────────────
 
 [env:native]
 platform = native
@@ -29,8 +102,11 @@ lib_deps =
     throwtheswitch/Unity@^2.5.2
     bblanchon/ArduinoJson
 test_build_src = yes
-; Exclude main.cpp (Arduino setup/loop entry points) from native test builds
-build_src_filter = +<*> -<main.cpp>
+; Exclude main.cpp and main_nrf.cpp from native test builds.
+build_src_filter =
+    +<*>
+    -<main.cpp>
+    -<main_nrf.cpp>
 build_flags =
     -std=gnu++17
     -D UNITY_INCLUDE_CONFIG_H

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,6 +8,8 @@ framework = arduino
 monitor_speed = 115200
 board_build.filesystem = littlefs
 build_unflags = -std=gnu++11
+; main_nrf.cpp is the nRF52 entry point — exclude it from all ESP32 builds.
+build_src_filter = +<*> -<main_nrf.cpp>
 lib_deps =
     fastled/FastLED@3.9.7
     bblanchon/ArduinoJson

--- a/src/NMEAParser.cpp
+++ b/src/NMEAParser.cpp
@@ -65,20 +65,16 @@ std::vector<std::string> NMEAParser::split(const std::string& sentence) {
 
 double NMEAParser::parseDouble(const std::string& f, double def) {
     if (f.empty()) return def;
-    try {
-        return std::stod(f);
-    } catch (...) {
-        return def;
-    }
+    char* end;
+    double v = std::strtod(f.c_str(), &end);
+    return (end != f.c_str()) ? v : def;
 }
 
 int NMEAParser::parseInt(const std::string& f, int def) {
     if (f.empty()) return def;
-    try {
-        return std::stoi(f);
-    } catch (...) {
-        return def;
-    }
+    char* end;
+    long v = std::strtol(f.c_str(), &end, 10);
+    return (end != f.c_str()) ? static_cast<int>(v) : def;
 }
 
 bool NMEAParser::parseTime(const std::string& val,

--- a/src/SensorManager.cpp
+++ b/src/SensorManager.cpp
@@ -29,7 +29,9 @@ SensorManager::SensorManager(I2CInterface& bus) : bus_(bus) {}
 // ---------------------------------------------------------------------------
 
 std::vector<I2CDevice> SensorManager::scanBus() {
+    #ifndef MCP_NO_THREADS
     std::lock_guard<std::mutex> lk(mutex_);
+    #endif
 
     // Clear previous state
     devices_.clear();
@@ -65,7 +67,9 @@ std::vector<I2CDevice> SensorManager::scanBus() {
 }
 
 int SensorManager::initDrivers() {
+    #ifndef MCP_NO_THREADS
     std::lock_guard<std::mutex> lk(mutex_);
+    #endif
 
     int count = 0;
     for (auto& drv : drivers_) {
@@ -79,7 +83,9 @@ int SensorManager::initDrivers() {
 // ---------------------------------------------------------------------------
 
 std::vector<SensorReading> SensorManager::readAll() {
+    #ifndef MCP_NO_THREADS
     std::lock_guard<std::mutex> lk(mutex_);
+    #endif
 
     std::vector<SensorReading> all;
     for (auto& drv : drivers_) {
@@ -92,7 +98,9 @@ std::vector<SensorReading> SensorManager::readAll() {
 
 std::vector<SensorReading> SensorManager::readSensor(
     const std::string& sensorId) {
+    #ifndef MCP_NO_THREADS
     std::lock_guard<std::mutex> lk(mutex_);
+    #endif
 
     auto it = driverIndex_.find(sensorId);
     if (it == driverIndex_.end()) return {};
@@ -106,12 +114,16 @@ std::vector<SensorReading> SensorManager::readSensor(
 // ---------------------------------------------------------------------------
 
 std::vector<I2CDevice> SensorManager::getDevices() const {
+    #ifndef MCP_NO_THREADS
     std::lock_guard<std::mutex> lk(mutex_);
+    #endif
     return devices_;
 }
 
 int SensorManager::driverCount() const {
+    #ifndef MCP_NO_THREADS
     std::lock_guard<std::mutex> lk(mutex_);
+    #endif
     return static_cast<int>(drivers_.size());
 }
 
@@ -130,7 +142,9 @@ static void appendStr(std::string& out, const std::string& s) {
 }
 
 std::string SensorManager::buildScanResponse(uint32_t id) const {
+    #ifndef MCP_NO_THREADS
     std::lock_guard<std::mutex> lk(mutex_);
+    #endif
 
     std::string r = "{\"jsonrpc\":\"2.0\",\"id\":";
     char tmp[32];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include "board_config.h"
 #include <Arduino.h>
 #include <LittleFS.h>
 #include <Wire.h>
@@ -138,8 +139,8 @@ void setup() {
     // if not previously set).  Must be called before networkManager.begin() so
     // the mDNS/broadcast callbacks fire correctly when the network comes up.
     DiscoveryConfig discoveryCfg;
-    discoveryCfg.mcpPort  = 9000;
-    discoveryCfg.httpPort = 80;
+    discoveryCfg.mcpPort  = BOARD_MCP_PORT;
+    discoveryCfg.httpPort = BOARD_HTTP_PORT;
     discoveryManager.begin(discoveryCfg);
     networkManager.setDiscoveryManager(&discoveryManager);
 
@@ -162,7 +163,7 @@ void setup() {
     discoveryManager.announceCapabilityChange();
 
     // Initialize I2C and scan for sensors
-    i2cBus.begin();
+    i2cBus.begin(BOARD_I2C_SDA, BOARD_I2C_SCL, BOARD_I2C_FREQ);
     sensorManager = new SensorManager(i2cBus);
     auto devices = sensorManager->scanBus();
     Serial.printf("Found %d I2C device(s)\n", (int)devices.size());

--- a/src/main_nrf.cpp
+++ b/src/main_nrf.cpp
@@ -10,6 +10,11 @@
 #include "board_config.h"
 #include <Arduino.h>
 #include <Wire.h>
+// Arduino.h defines min/max as C macros which conflict with std::min/std::max
+// template declarations inside <functional> (pulled in by SensorManager.h).
+// Undefine them here, after all Arduino headers are processed.
+#undef min
+#undef max
 #include "I2CInterface.h"
 #include "SensorManager.h"
 

--- a/src/main_nrf.cpp
+++ b/src/main_nrf.cpp
@@ -1,0 +1,164 @@
+// main_nrf.cpp — Entry point for nRF52840 builds (sensor-only, no WiFi).
+//
+// WiFi-dependent subsystems (NetworkManager, MCPServer, DiscoveryManager) are
+// excluded from nRF builds via build_src_filter in platformio.ini.  This file
+// replaces main.cpp and provides a minimal setup that:
+//   • initialises the I2C bus using BOARD_I2C_SDA / SCL from board_config.h
+//   • scans for supported sensors and initialises their drivers
+//   • prints sensor readings to Serial every 2 seconds
+
+#include "board_config.h"
+#include <Arduino.h>
+#include <Wire.h>
+#include "I2CInterface.h"
+#include "SensorManager.h"
+#include "MetricsSystem.h"
+
+// ---------------------------------------------------------------------------
+// Concrete I2C implementation for nRF52840 (Arduino Wire)
+//
+// The nRF52 Arduino core does not support runtime SDA/SCL remapping; pins are
+// fixed by the board variant.  The sda/scl parameters are accepted but ignored
+// so that this class satisfies the I2CInterface contract.
+// ---------------------------------------------------------------------------
+class NRF52I2CInterface : public mcp::I2CInterface {
+public:
+    bool begin(int /*sda*/ = -1, int /*scl*/ = -1,
+               uint32_t freq = 100000) override {
+        Wire.begin();
+        Wire.setClock(freq);
+        return true;
+    }
+    bool devicePresent(uint8_t address) override {
+        Wire.beginTransmission(address);
+        return (Wire.endTransmission() == 0);
+    }
+    std::vector<uint8_t> scan() override {
+        std::vector<uint8_t> found;
+        for (uint8_t addr = 1; addr < 127; ++addr)
+            if (devicePresent(addr)) found.push_back(addr);
+        return found;
+    }
+    bool writeReg8(uint8_t addr, uint8_t reg, uint8_t val) override {
+        Wire.beginTransmission(addr);
+        Wire.write(reg); Wire.write(val);
+        return (Wire.endTransmission() == 0);
+    }
+    bool writeReg16(uint8_t addr, uint8_t reg, uint16_t val) override {
+        Wire.beginTransmission(addr);
+        Wire.write(reg); Wire.write(val >> 8); Wire.write(val & 0xFF);
+        return (Wire.endTransmission() == 0);
+    }
+    uint8_t readReg8(uint8_t addr, uint8_t reg) override {
+        Wire.beginTransmission(addr); Wire.write(reg); Wire.endTransmission(false);
+        Wire.requestFrom(addr, (uint8_t)1);
+        return Wire.available() ? Wire.read() : 0;
+    }
+    int16_t readReg16s(uint8_t addr, uint8_t reg) override {
+        Wire.beginTransmission(addr); Wire.write(reg); Wire.endTransmission(false);
+        Wire.requestFrom(addr, (uint8_t)2);
+        uint8_t hi = Wire.available() ? Wire.read() : 0;
+        uint8_t lo = Wire.available() ? Wire.read() : 0;
+        return static_cast<int16_t>((hi << 8) | lo);
+    }
+    uint16_t readReg16u(uint8_t addr, uint8_t reg) override {
+        return static_cast<uint16_t>(readReg16s(addr, reg));
+    }
+    bool readBytes(uint8_t addr, uint8_t reg, uint8_t* buf, size_t len) override {
+        Wire.beginTransmission(addr); Wire.write(reg); Wire.endTransmission(false);
+        Wire.requestFrom(addr, (uint8_t)len);
+        for (size_t i = 0; i < len; ++i) buf[i] = Wire.available() ? Wire.read() : 0;
+        return true;
+    }
+    bool writeBytes(uint8_t addr, uint8_t reg,
+                    const uint8_t* buf, size_t len) override {
+        Wire.beginTransmission(addr); Wire.write(reg);
+        for (size_t i = 0; i < len; ++i) Wire.write(buf[i]);
+        return (Wire.endTransmission() == 0);
+    }
+    bool sendCommand(uint8_t addr, uint8_t cmd) override {
+        Wire.beginTransmission(addr); Wire.write(cmd);
+        return (Wire.endTransmission() == 0);
+    }
+    size_t readRaw(uint8_t addr, uint8_t* buf, size_t len) override {
+        Wire.requestFrom(addr, (uint8_t)len);
+        size_t n = 0;
+        while (Wire.available() && n < len) buf[n++] = Wire.read();
+        return n;
+    }
+    void delayMs(uint32_t ms) override { delay(ms); }
+};
+
+using namespace mcp;
+
+// ---------------------------------------------------------------------------
+// Globals
+// ---------------------------------------------------------------------------
+static NRF52I2CInterface i2cBus;
+static SensorManager*   sensorManager = nullptr;
+
+// ---------------------------------------------------------------------------
+// setup
+// ---------------------------------------------------------------------------
+void setup() {
+    Serial.begin(BOARD_SERIAL_BAUD);
+    // Wait up to 3 s for serial terminal (USB CDC) — skip if nothing connects.
+    for (int i = 0; i < 30 && !Serial; ++i) delay(100);
+
+    Serial.println("=== ESP32MCPServer — nRF52840 sensor node ===");
+    Serial.print("Board: "); Serial.println(BOARD_NAME);
+
+    // Initialise I2C.  On nRF52 the SDA/SCL pins come from the variant so
+    // the sda/scl arguments are ignored by NRF52I2CInterface::begin().
+    i2cBus.begin(BOARD_I2C_SDA, BOARD_I2C_SCL, BOARD_I2C_FREQ);
+
+    sensorManager = new SensorManager(i2cBus);
+    auto devices = sensorManager->scanBus();
+    Serial.print("I2C devices found: ");
+    Serial.println((int)devices.size());
+    for (auto& d : devices) {
+        Serial.print("  0x");
+        if (d.address < 0x10) Serial.print('0');
+        Serial.print(d.address, HEX);
+        Serial.print("  ");
+        Serial.print(d.name.c_str());
+        Serial.println(d.supported ? "  [supported]" : "  [unknown]");
+    }
+
+    int inited = sensorManager->initDrivers();
+    Serial.print("Sensor drivers initialised: ");
+    Serial.println(inited);
+    Serial.println("Reporting readings every 2 s...");
+}
+
+// ---------------------------------------------------------------------------
+// loop — periodic sensor read and Serial print
+// ---------------------------------------------------------------------------
+void loop() {
+    delay(2000);
+
+    const auto& devices = sensorManager->getDevices();
+    if (devices.empty()) {
+        Serial.println("[no sensors]");
+        return;
+    }
+
+    for (const auto& dev : devices) {
+        if (!dev.supported) continue;
+        // Build a sensor id the same way SensorManager does
+        char addrBuf[8];
+        snprintf(addrBuf, sizeof(addrBuf), "0x%02x", dev.address);
+        std::string lower = dev.name;
+        for (char& c : lower) c = static_cast<char>(tolower(c));
+        std::string sid = lower + "_" + addrBuf;
+
+        // buildReadResponse returns a JSON-RPC string; parse out the result
+        // values and print them to Serial.
+        std::string resp = sensorManager->buildReadResponse(0, sid);
+        Serial.print(dev.name.c_str());
+        Serial.print(" @ "); Serial.print(addrBuf);
+        Serial.print(": ");
+        // Print the raw JSON response (compact but human-readable on terminal)
+        Serial.println(resp.c_str());
+    }
+}

--- a/src/main_nrf.cpp
+++ b/src/main_nrf.cpp
@@ -12,7 +12,6 @@
 #include <Wire.h>
 #include "I2CInterface.h"
 #include "SensorManager.h"
-#include "MetricsSystem.h"
 
 // ---------------------------------------------------------------------------
 // Concrete I2C implementation for nRF52840 (Arduino Wire)

--- a/src/main_nrf.cpp
+++ b/src/main_nrf.cpp
@@ -10,11 +10,17 @@
 #include "board_config.h"
 #include <Arduino.h>
 #include <Wire.h>
-// Arduino.h defines min/max as C macros which conflict with std::min/std::max
-// template declarations inside <functional> (pulled in by SensorManager.h).
-// Undefine them here, after all Arduino headers are processed.
+// Arduino.h / math.h define min, max, abs, and round as single- or two-
+// argument C macros.  When C++ STL headers are included afterwards (via
+// SensorManager.h → <functional>, <mutex> → <chrono>) the preprocessor
+// mis-parses template argument lists (the comma in e.g.
+// std::chrono::round<Rep, Period>() looks like a second macro argument),
+// producing cascading parse errors.  Undefine all four after Arduino headers
+// are done and before any project header that pulls in STL.
 #undef min
 #undef max
+#undef abs
+#undef round
 #include "I2CInterface.h"
 #include "SensorManager.h"
 


### PR DESCRIPTION
Board configuration headers (include/boards/)
- board_esp32_s3_devkitc1.h  — ESP32-S3-DevKitC-1 (existing default)
- board_esp32_devkitc.h      — ESP32 DevKitC V4 (classic, most common)
- board_esp32_c3_devkitm1.h  — ESP32-C3-DevKitM-1 (RISC-V, budget IoT)
- board_adafruit_huzzah32.h  — Adafruit HUZZAH32 ESP32 Feather
- board_m5stack_core.h       — M5Stack Core ESP32 (with GPIO conflict map)
- board_nrf52840_dk.h        — Nordic nRF52840-DK (sensor-only, no WiFi)
- board_nrf52840_feather.h   — Adafruit Feather nRF52840 (sensor-only)

Each header defines: BOARD_NAME, BOARD_HAS_WIFI/BLE/CAN, BOARD_I2C_SDA/SCL,
BOARD_I2C_FREQ, BOARD_UART_TX/RX, BOARD_UART1_TX/RX, BOARD_LED_PIN,
BOARD_CAN_TX/RX, BOARD_SERIAL_BAUD, BOARD_MCP_PORT, BOARD_HTTP_PORT.

Selector header (include/board_config.h)
- Picks the right board header based on -D BOARD_* build flag
- Falls back to ESP32-S3-DevKitC-1 for backwards compatibility

Wiring documentation (docs/boards/)
- One Markdown file per board with pinout diagram, I2C sensor wiring
  table (all 6 supported sensors with address-select info), CAN/UART
  wiring diagrams, build config snippet, and board-specific notes

NRF52840 sensor-only entry point (src/main_nrf.cpp)
- Replaces main.cpp for nRF builds (excluded via build_src_filter)
- NRF52I2CInterface wraps Arduino Wire (no runtime pin remapping)
- Scans I2C bus, initialises drivers, prints readings to Serial CDC
- WiFi/WebSocket/mDNS subsystems not compiled (not available on nRF)

src/main.cpp
- #include "board_config.h" added
- i2cBus.begin() now passes BOARD_I2C_SDA/SCL/FREQ instead of defaults
- DiscoveryConfig ports use BOARD_MCP_PORT / BOARD_HTTP_PORT macros

platformio.ini
- [esp32_base] shared section holds all ESP32/Arduino common settings
- [nrf52_base] shared section holds nRF52 settings + build_src_filter
  that excludes WiFi-dependent sources and adds main_nrf.cpp
- 5 ESP32 [env:*] sections (s3-devkitc-1, devkitc, c3, huzzah32, m5stack)
- 2 nRF52 [env:*] sections (nrf52840-dk, nrf52840-feather)
- [env:native] excludes both main.cpp and main_nrf.cpp

.github/workflows/build.yml
- firmware job replaced with matrix strategy (fail-fast: false)
- 7 board targets run in parallel after native tests pass
- Per-board cache keys (pio-<platform>-<env>-<hash>)
- Artifacts: firmware.bin (ESP32) or firmware.hex (nRF52), 14-day retention

https://claude.ai/code/session_01KcwgryFgMCJubfjtwqMnUc